### PR TITLE
add check for has many relation

### DIFF
--- a/src/CanGelis/DataModels/XmlModel.php
+++ b/src/CanGelis/DataModels/XmlModel.php
@@ -176,11 +176,14 @@ class XmlModel extends DataModel
     protected function resolveHasManyRelationship($relation)
     {
         $items = [];
-        foreach ($this->data->{$relation}->children() as $child) {
-            $items[] = new $this->hasMany[$relation]($child, $child->getName());
-        }
 
-        unset($this->data->{$relation});
+        if (isset($this->data->{$relation})) {
+            foreach ($this->data->{$relation}->children() as $child) {
+                $items[] = new $this->hasMany[$relation]($child, $child->getName());
+            }
+
+            unset($this->data->{$relation});
+        }
 
         return $this->makeCollection($items);
     }


### PR DESCRIPTION
Fix for function `resolveHasManyRelationship()` when hasMany relation items does not exist in the original XML:

> "message": "foreach() argument must be of type array|object, null given",
> "file": "/vendor/cangelis/data-models/src/CanGelis/DataModels/XmlModel.php",
> "line": 179